### PR TITLE
Updated method1 to skip a directory when only a single file is found

### DIFF
--- a/veeam-fastclone-stats/veeam_refs_savings.ps1
+++ b/veeam-fastclone-stats/veeam_refs_savings.ps1
@@ -67,16 +67,20 @@ function blockstatwrapper {
 #method one, list files, should be the easiest
 function method1 {
     param($exe,$listfilepath,$outputpath)
-    
 
     #$files = Get-ChildItem -Path $dir -Recurse -Depth 10 -file -Include "*.vbk","*.vib","*.vrb" | % { $_.FullName } 
     $filesgroup = Get-ChildItem -Path $dir -Recurse -Depth 10 -file -Include "*.vbk","*.vib","*.vrb" | Group-Object -Property directory
     foreach ($gr in $filesgroup) {
-
+        
+        Write-host "Processing" $gr.name        
         $files = $gr.group | % { $_.FullName }
-        $files | Set-Content -Path $listfilepath -Encoding Unicode
-        blockstatwrapper -exe $exe -listfilepath $listfilepath -outputpath $outputpath
-
+        if ($files.count -gt 1){
+            $files | Set-Content -Path $listfilepath -Encoding Unicode
+            blockstatwrapper -exe $exe -listfilepath $listfilepath -outputpath $outputpath
+        }
+        else {
+            write-host "Only 1 file found. Skipping " $gr.Name 
+        }
     }
     
 }


### PR DESCRIPTION
When only a single file is found, we should skip this directory.  Fixes https://github.com/VeeamHub/grafana/issues/9

# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # https://github.com/VeeamHub/grafana/issues/9

### Type of change

* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Tested on my system

### Checklist (check all applicable):

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in _hard to understand_ areas
* [X] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [X] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
