### PR TITLE
Adjust for lastruntimeunix being negative

### DIFF
--- a/veeam-availability-console-grafana/veeam-availability-console-script.sh
+++ b/veeam-availability-console-grafana/veeam-availability-console-script.sh
@@ -318,7 +318,7 @@ for id in $(echo "$veeamJobsUrl" | jq -r '.[].id'); do
     typeJob=$(echo "$veeamJobsUrl" | jq --raw-output ".[$arrayJobs].type" | awk '{gsub(/ /,"\\ ");print}')    
     lastRunJob=$(echo "$veeamJobsUrl" | jq --raw-output ".[$arrayJobs].lastRun")
     lastRunTimeUnix=$(date -d "$lastRunJob" +"%s")
-    if [[ $lastRunTimeUnix = "-62135596725" ]]; then
+    if [[ $lastRunTimeUnix < "0" ]]; then
             lastRunTimeUnix="1"
     fi
     totalDuration=$(echo "$veeamJobsUrl" | jq --raw-output ".[$arrayJobs].duration")


### PR DESCRIPTION
We know no jobs will ever have run since before Unix epoch 0, so lets just set them all to 1.
This prevents an error that I was seeing when the epoch time was a different negative value than listed in this script.

# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

### Type of change

* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Tested it on my environment. 

### Checklist (check all applicable):

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in _hard to understand_ areas
* [X] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [X] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
